### PR TITLE
Update readme to deploy overpass-turbo - frontend 

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ Development is done in the _master_ branch, stable releases are marked with git 
 2. `npm start` for a Development server listening at http://localhost:8080
 3. `npm run build` for a minified build in `./build`
 
-### deploying to GH Pages
+## Deploy to Staging and Production
 
-Running `npm run deploy` will do `npm run build && gh-pages -d build` and deploy the build artifacts to the GH Pages branch.
+Overpass-turbo has been configured in [OHM-deploy](https://github.com/OpenHistoricalMap/ohm-deploy) to deployment in production and staging, you just need to update the gitsha you want to launch [here](https://github.com/OpenHistoricalMap/ohm-deploy/blob/main/.github/workflows/frontend-overpass.yaml#L36). Gtihub action will automatically deploy the changes.
+
+Changes can be see it at:
+
+- Production: https://overpass-turbo.openhistoricalmap.org/
+- Staging: https://overpass-turbo-staging.openhistoricalmap.org/


### PR DESCRIPTION
From: https://github.com/OpenHistoricalMap/ohm-deploy/pull/204#pullrequestreview-1279252949

Adding documentation to deploy overpass-turbo - frontend  in ohm-deploy.

cc. @danrademacher