### PR TITLE
355 raster tiles are hidden behind vector tiles

### DIFF
--- a/js/ide.ts
+++ b/js/ide.ts
@@ -493,8 +493,9 @@ class IDE {
     ide.attribControl = new L.Control.Attribution({prefix: false});
     ide.attribControl.addAttribution(tilesAttrib);
     const pos = new L.LatLng(settings.coords_lat, settings.coords_lon);
-    ide.map.setView(pos, settings.coords_zoom).addLayer(tiles);
-    ide.map.tile_layer = tiles;
+    ide.map.setView(pos, settings.coords_zoom);
+    //  .addLayer(tiles);
+    // ide.map.tile_layer = tiles;
 
     // OHM: add vector layer
     ide.map.createPane("ohm_vectortiles");

--- a/js/ide.ts
+++ b/js/ide.ts
@@ -477,7 +477,7 @@ class IDE {
 
     // init leaflet
     ide.map = new L.Map("map", {
-      attributionControl: true,
+      attributionControl: false,
       minZoom: 0,
       maxZoom: configs.maxMapZoom,
       worldCopyJump: false
@@ -490,8 +490,9 @@ class IDE {
       maxNativeZoom: 19,
       maxZoom: ide.map.options.maxZoom
     });
-    ide.attribControl = new L.Control.Attribution({prefix: false});
-    ide.attribControl.addAttribution(tilesAttrib);
+    const attribControl = new L.Control.Attribution({position: "bottomright"});
+    attribControl.addAttribution(tilesAttrib);
+    attribControl.addTo(ide.map);
     const pos = new L.LatLng(settings.coords_lat, settings.coords_lon);
     ide.map.setView(pos, settings.coords_zoom);
     //  .addLayer(tiles);

--- a/js/map.ts
+++ b/js/map.ts
@@ -131,7 +131,8 @@ $(document).ready(() => {
   const tilesUrl = settings.tileServer;
   const tilesAttrib = configs.tileServerAttribution;
   const tiles = new L.TileLayer(tilesUrl, {attribution: tilesAttrib});
-  ide.map.setView([0, 0], 1).addLayer(tiles);
+  ide.map.setView([0, 0], 1);
+  // .addLayer(tiles);
   const scaleControl = new L.Control.Scale({metric: true, imperial: false});
   scaleControl.addTo(ide.map);
   // wait spinner


### PR DESCRIPTION
Fixes https://github.com/OpenHistoricalMap/issues/issues/355 by never adding Leaflet/OSM layer to the map.

Done by commenting out chained commands to act as a future reminder that upstream is different on purpose.

This PR also disables the attribution control when the map is initialized, then properly adds it; upstream gets this addition wrong and a PR has been opened against upstream code.